### PR TITLE
feat: expose big decimal custom schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.3 - 2025-4-21
+
+Here I'm exposing this custom schema in a separated entrypoint to don't make the whole package be bigger just because of it.
+
+
 # 1.0.2 - 2025-4-13
 
 Just testing the beta releases

--- a/package-lock.json
+++ b/package-lock.json
@@ -509,6 +509,17 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@omariosouto/common-core": {
+      "version": "1.0.3",
+      "resolved": "https://npm.pkg.github.com/download/@omariosouto/common-core/1.0.3/3a3716e6a433d4003bc825383bff575ebd3b144c",
+      "integrity": "sha512-thME06AoivwR17MI0w1JERv6ZN2j/Yx5Hc7B72Wo9H1EgyojFUCL0DpoYz8yhDifD2z0ZQYlVJNsbTj7XphhgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js": "^10.5.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
     "node_modules/@omariosouto/common-schema": {
       "resolved": "packages/lib",
       "link": true
@@ -996,6 +1007,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -1191,6 +1209,13 @@
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
@@ -1915,10 +1940,14 @@
         "zod": "^3.24.2"
       },
       "devDependencies": {
+        "@omariosouto/common-core": "1.0.3",
         "@omariosouto/tsconfig": "1.13.11",
         "@types/node": "^22.14.1",
         "tsup": "^8.4.0",
         "typescript": "^5.0.0"
+      },
+      "peerDependencies": {
+        "@omariosouto/common-core": "*"
       }
     }
   }

--- a/packages/lib/CHANGELOG.md
+++ b/packages/lib/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.3 - 2025-4-21
+
+Here I'm exposing this custom schema in a separated entrypoint to don't make the whole package be bigger just because of it.
+
+
 # 1.0.2 - 2025-4-13
 
 Just testing the beta releases

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omariosouto/common-schema",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "description": "",
   "exports": {
+    "./big-decimal": "./dist/big-decimal.js",
     ".": "./dist/index.js",
     "./test": "./dist/test.js"
   },
@@ -22,10 +23,14 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   },
+  "peerDependencies": {
+    "@omariosouto/common-core": "*"
+  },
   "dependencies": {
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@omariosouto/common-core": "1.0.3",
     "@omariosouto/tsconfig": "1.13.11",
     "@types/node": "^22.14.1",
     "tsup": "^8.4.0",

--- a/packages/lib/src/big-decimal.ts
+++ b/packages/lib/src/big-decimal.ts
@@ -1,0 +1,1 @@
+export * from "./custom/bigDecimal";

--- a/packages/lib/src/custom/bigDecimal.ts
+++ b/packages/lib/src/custom/bigDecimal.ts
@@ -1,0 +1,20 @@
+import { BigDecimal } from "@omariosouto/common-core";
+import { s } from "../schema";
+
+export const bigDecimalSchema = s
+  .union([                       // tipos de entrada aceitos
+    s.instanceof(BigDecimal),         // já é Money
+    s.number(),                  // 10  → R$ 10,00
+    s.string(),                  // "10.50" → R$ 10,50 (ou USD 10.50, depende de opções)
+  ])
+  .transform<BigDecimal>((raw, ctx) => {
+    try {
+      return new BigDecimal(raw as BigDecimal);
+    } catch (err) {
+      ctx.addIssue({
+        code:  "custom",
+        message: "Valor inválido para Money",
+      });
+      return s.NEVER;
+    }
+  });

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,1 +1,1 @@
-export { z as s } from "zod";
+export { s } from "./schema";

--- a/packages/lib/src/schema/index.ts
+++ b/packages/lib/src/schema/index.ts
@@ -1,0 +1,1 @@
+export { z as s } from "zod";


### PR DESCRIPTION
## Lib Management

| Commands to manage version bumps |
| --- |
| bumper/release |
| bumper/beta    |
| bumper/skip    |

## Changelog

Here I'm exposing this custom schema in a separated entrypoint to don't make the whole package be bigger just because of it.
