### PR TITLE
feat: add essentials to work with schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.0.4 - 2025-4-21
+
+Adding support to:
+- Throws `SchemaError`, always when using `parseSchema`
+- When you are testing, you need to have fake data, for that use `generate` from the `/test` scope
+
+
 # 1.0.3 - 2025-4-21
 
 Here I'm exposing this custom schema in a separated entrypoint to don't make the whole package be bigger just because of it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -550,6 +550,13 @@
         "lodash-es": "^4.17.21"
       }
     },
+    "node_modules/@omariosouto/common-errors": {
+      "version": "1.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@omariosouto/common-errors/1.0.1/572d404306c567680174faa2511fad75c108f837",
+      "integrity": "sha512-MAyMZqOsjBvZ+tm6LB+28k06cX8fctPZTAq54Sj8cfOE3Z7s2PlMPWtLhgfqXZCg4a3AFto4BeTda5qlwpqzOw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@omariosouto/common-schema": {
       "resolved": "packages/lib",
       "link": true
@@ -2543,6 +2550,7 @@
       },
       "devDependencies": {
         "@omariosouto/common-core": "1.0.4",
+        "@omariosouto/common-errors": "1.0.1",
         "@omariosouto/tsconfig": "2.0.1",
         "@types/lodash-es": "^4.17.12",
         "@types/node": "^22.14.1",
@@ -2551,7 +2559,8 @@
         "vitest": "^3.1.2"
       },
       "peerDependencies": {
-        "@omariosouto/common-core": "*"
+        "@omariosouto/common-core": "*",
+        "@omariosouto/common-errors": "*"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,19 @@
         "packages/*"
       ]
     },
+    "node_modules/@anatine/zod-mock": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@anatine/zod-mock/-/zod-mock-3.14.0.tgz",
+      "integrity": "sha512-pTYyn9dlszUl5gMGWtE7DBRvx1EcqpBJ1iJ73rlJYCZr9lgIEdZ6PCZQqoXIdlC8DYIwuT1M3/N8arkJa7A10Q==",
+      "license": "MIT",
+      "dependencies": {
+        "randexp": "^0.5.3"
+      },
+      "peerDependencies": {
+        "@faker-js/faker": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "zod": "^3.21.4"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.2",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz",
@@ -438,6 +451,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/@faker-js/faker": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.7.0.tgz",
+      "integrity": "sha512-aozo5vqjCmDoXLNUJarFZx2IN/GgGaogY4TMJ6so/WLZOWpSV7fvj2dmrV6sEAnUm1O7aCrhTibjpzeDFgNqbg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -832,6 +862,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.14.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
@@ -840,6 +887,119 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.2.tgz",
+      "integrity": "sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.1.2",
+        "@vitest/utils": "3.1.2",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.2.tgz",
+      "integrity": "sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
+      "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.2.tgz",
+      "integrity": "sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.2.tgz",
+      "integrity": "sha512-Q1qkpazSF/p4ApZg1vfZSQ5Yw6OCQxVMVrLjslbLFA1hMDrT2uxtqMaw8Tc/jy5DLka1sNs1Y7rBcftMiaSH/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.1.2",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.2.tgz",
+      "integrity": "sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.2.tgz",
+      "integrity": "sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.1.2",
+        "loupe": "^3.1.3",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/ansi-regex": {
@@ -874,6 +1034,16 @@
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -916,6 +1086,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -1014,6 +1211,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/drange": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
+      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -1025,6 +1241,13 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1069,10 +1292,30 @@
         "@esbuild/win32-x64": "0.25.2"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+      "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1224,12 +1467,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
     },
     "node_modules/minimatch": {
       "version": "9.0.5",
@@ -1276,6 +1536,25 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1320,6 +1599,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1348,6 +1644,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.8",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postcss-load-config": {
@@ -1403,6 +1728,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/randexp": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
+      "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
+      "license": "MIT",
+      "dependencies": {
+        "drange": "^1.0.2",
+        "ret": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -1425,6 +1763,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/rollup": {
@@ -1490,6 +1837,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -1515,6 +1869,30 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -1666,6 +2044,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -1674,13 +2059,13 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
-      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
+      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.3",
+        "fdir": "^6.4.4",
         "picomatch": "^4.0.2"
       },
       "engines": {
@@ -1688,6 +2073,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tr46": {
@@ -1790,6 +2205,175 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vite": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.2.tgz",
+      "integrity": "sha512-ZSvGOXKGceizRQIZSz7TGJ0pS3QLlVY/9hwxVh17W3re67je1RKYzFHivZ/t0tubU78Vkyb9WnHPENSBCzbckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.3",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.12"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.2.tgz",
+      "integrity": "sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.0",
+        "es-module-lexer": "^1.6.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.2.tgz",
+      "integrity": "sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "3.1.2",
+        "@vitest/mocker": "3.1.2",
+        "@vitest/pretty-format": "^3.1.2",
+        "@vitest/runner": "3.1.2",
+        "@vitest/snapshot": "3.1.2",
+        "@vitest/spy": "3.1.2",
+        "@vitest/utils": "3.1.2",
+        "chai": "^5.2.0",
+        "debug": "^4.4.0",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.13",
+        "tinypool": "^1.0.2",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0",
+        "vite-node": "3.1.2",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.1.2",
+        "@vitest/ui": "3.1.2",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -1823,6 +2407,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -1934,17 +2535,20 @@
     },
     "packages/lib": {
       "name": "@omariosouto/common-schema",
-      "version": "1.0.0",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
+        "@anatine/zod-mock": "^3.14.0",
         "zod": "^3.24.2"
       },
       "devDependencies": {
         "@omariosouto/common-core": "1.0.3",
         "@omariosouto/tsconfig": "1.13.11",
+        "@types/lodash-es": "^4.17.12",
         "@types/node": "^22.14.1",
         "tsup": "^8.4.0",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0",
+        "vitest": "^3.1.2"
       },
       "peerDependencies": {
         "@omariosouto/common-core": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -540,9 +540,9 @@
       }
     },
     "node_modules/@omariosouto/common-core": {
-      "version": "1.0.3",
-      "resolved": "https://npm.pkg.github.com/download/@omariosouto/common-core/1.0.3/3a3716e6a433d4003bc825383bff575ebd3b144c",
-      "integrity": "sha512-thME06AoivwR17MI0w1JERv6ZN2j/Yx5Hc7B72Wo9H1EgyojFUCL0DpoYz8yhDifD2z0ZQYlVJNsbTj7XphhgA==",
+      "version": "1.0.4",
+      "resolved": "https://npm.pkg.github.com/download/@omariosouto/common-core/1.0.4/a869fceeca929084ef48614a7f4a31b955525ccb",
+      "integrity": "sha512-spEJdruOj6RvS5JUXkUXk1cvu5oq2iarknpUFaeEAAlaxDEe4rMBw7pnRjUimN0x0Az4CrowDdU3afY4BiYhCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -555,9 +555,9 @@
       "link": true
     },
     "node_modules/@omariosouto/tsconfig": {
-      "version": "1.13.11",
-      "resolved": "https://npm.pkg.github.com/download/@omariosouto/tsconfig/1.13.11/17d79fb0feb3816eb370405e5378392a12a8414c",
-      "integrity": "sha512-0HgiGd1UuVgdL6eYBkHeWrrAauqlszqN5gQbXarrZOmKZXqkV6+bhkr1TpM4AGt9ve99NoYgg1LVTkls29/tBg==",
+      "version": "2.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@omariosouto/tsconfig/2.0.1/b358151737771e31045992d170c0839cd66a5772",
+      "integrity": "sha512-6dfD5JOGvAPtiKbPoW0LF0RHbIQblI11eaa1pwRfE001HSId37Ilakaj9aH5akqHqKyF1klaaMG2ggxt4gJ95g==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2542,8 +2542,8 @@
         "zod": "^3.24.2"
       },
       "devDependencies": {
-        "@omariosouto/common-core": "1.0.3",
-        "@omariosouto/tsconfig": "1.13.11",
+        "@omariosouto/common-core": "1.0.4",
+        "@omariosouto/tsconfig": "2.0.1",
         "@types/lodash-es": "^4.17.12",
         "@types/node": "^22.14.1",
         "tsup": "^8.4.0",

--- a/packages/lib/CHANGELOG.md
+++ b/packages/lib/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.0.4 - 2025-4-21
+
+Adding support to:
+- Throws `SchemaError`, always when using `parseSchema`
+- When you are testing, you need to have fake data, for that use `generate` from the `/test` scope
+
+
 # 1.0.3 - 2025-4-21
 
 Here I'm exposing this custom schema in a separated entrypoint to don't make the whole package be bigger just because of it.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -31,8 +31,8 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "@omariosouto/common-core": "1.0.3",
-    "@omariosouto/tsconfig": "1.13.11",
+    "@omariosouto/common-core": "1.0.4",
+    "@omariosouto/tsconfig": "2.0.1",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.14.1",
     "tsup": "^8.4.0",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -24,13 +24,15 @@
     "registry": "https://npm.pkg.github.com"
   },
   "peerDependencies": {
-    "@omariosouto/common-core": "*"
+    "@omariosouto/common-core": "*",
+    "@omariosouto/common-errors": "*"
   },
   "dependencies": {
     "@anatine/zod-mock": "^3.14.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@omariosouto/common-errors": "1.0.1",
     "@omariosouto/common-core": "1.0.4",
     "@omariosouto/tsconfig": "2.0.1",
     "@types/lodash-es": "^4.17.12",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsup",
-    "test": "echo 'There are no tests. But things work trust me!'"
+    "test": "vitest"
   },
   "keywords": [],
   "author": "",
@@ -27,13 +27,16 @@
     "@omariosouto/common-core": "*"
   },
   "dependencies": {
+    "@anatine/zod-mock": "^3.14.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {
     "@omariosouto/common-core": "1.0.3",
     "@omariosouto/tsconfig": "1.13.11",
+    "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.14.1",
     "tsup": "^8.4.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vitest": "^3.1.2"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omariosouto/common-schema",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/lib/src/custom/bigDecimal.ts
+++ b/packages/lib/src/custom/bigDecimal.ts
@@ -2,18 +2,18 @@ import { BigDecimal } from "@omariosouto/common-core";
 import { s } from "../schema";
 
 export const bigDecimalSchema = s
-  .union([                       // tipos de entrada aceitos
-    s.instanceof(BigDecimal),         // já é Money
-    s.number(),                  // 10  → R$ 10,00
-    s.string(),                  // "10.50" → R$ 10,50 (ou USD 10.50, depende de opções)
+  .union([
+    s.instanceof(BigDecimal),
+    s.number(),
+    s.string(),
   ])
   .transform<BigDecimal>((raw, ctx) => {
     try {
       return new BigDecimal(raw as BigDecimal);
     } catch (err) {
       ctx.addIssue({
-        code:  "custom",
-        message: "Valor inválido para Money",
+        code: "custom",
+        message: "Invalid BigDecimal",
       });
       return s.NEVER;
     }

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,2 +1,1 @@
-export { s } from "./schema";
-export type { SchemaType } from "./schema";
+export * from "./schema/index";

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,7 +1,2 @@
 export { s } from "./schema";
 export type { SchemaType } from "./schema";
-
-// TODO: Make this available on next release
-export function parseSchema<Schema = SchemaType>(schema: Schema) {
-  return schema.parse();
-}

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,1 +1,7 @@
 export { s } from "./schema";
+export type { SchemaType } from "./schema";
+
+// TODO: Make this available on next release
+export function parseSchema<Schema = SchemaType>(schema: Schema) {
+  return schema.parse();
+}

--- a/packages/lib/src/schema/SchemaError.ts
+++ b/packages/lib/src/schema/SchemaError.ts
@@ -1,0 +1,19 @@
+import { CommonError } from "@omariosouto/common-errors";
+import { ZodError } from "zod";
+
+export class SchemaError extends CommonError {
+  constructor(error: ZodError) {
+    super({
+      name: "SchemaError",
+      message: "Schema validation failed",
+      code: "SCHEMA_VALIDATION_ERROR",
+      statusCode: 400,
+      details: {
+        issues: error.issues,
+        zodError: error, // opcional, caso queira ter o objeto inteiro disponível
+      },
+    });
+
+    this.stack = error.stack;
+  }
+}

--- a/packages/lib/src/schema/SchemaError.ts
+++ b/packages/lib/src/schema/SchemaError.ts
@@ -10,7 +10,7 @@ export class SchemaError extends CommonError {
       statusCode: 400,
       details: {
         issues: error.issues,
-        zodError: error, // opcional, caso queira ter o objeto inteiro disponível
+        baseError: error,
       },
     });
 

--- a/packages/lib/src/schema/index.ts
+++ b/packages/lib/src/schema/index.ts
@@ -1,2 +1,3 @@
 export { z as s } from "zod";
-export type { ZodType as SchemaType } from "zod";
+export * from "./types";
+export * from "./parse";

--- a/packages/lib/src/schema/index.ts
+++ b/packages/lib/src/schema/index.ts
@@ -1,1 +1,2 @@
 export { z as s } from "zod";
+export type { ZodType as SchemaType } from "zod";

--- a/packages/lib/src/schema/parse.test.ts
+++ b/packages/lib/src/schema/parse.test.ts
@@ -28,6 +28,7 @@ describe("Schema Parsing", () => {
       age: "thirty",
     };
 
+    // TODO: The error thrown must be of type SchemaError
     expect(() => parseSchema(schema, payload)).toThrow();
   });
 });

--- a/packages/lib/src/schema/parse.test.ts
+++ b/packages/lib/src/schema/parse.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { s } from "../schema";
+import { parseSchema } from "./parse";
+
+describe("Schema Parsing", () => {
+  it("should parse a valid schema", () => {
+    const schema = s.object({
+      name: s.string(),
+      age: s.number(),
+    });
+
+    const payload = {
+      name: "John Doe",
+      age: 30,
+    };
+
+    const parsed = parseSchema(schema, payload);
+    expect(parsed).toEqual(payload);
+  });
+  it("should throw an error for invalid schema", () => {
+    const schema = s.object({
+      name: s.string(),
+      age: s.number(),
+    });
+
+    const payload = {
+      name: "John Doe",
+      age: "thirty",
+    };
+
+    expect(() => parseSchema(schema, payload)).toThrow();
+  });
+});

--- a/packages/lib/src/schema/parse.test.ts
+++ b/packages/lib/src/schema/parse.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { s } from "../schema";
 import { parseSchema } from "./parse";
+import { SchemaError } from "./SchemaError";
+import { ZodError } from "zod";
 
 describe("Schema Parsing", () => {
   it("should parse a valid schema", () => {
@@ -28,7 +30,8 @@ describe("Schema Parsing", () => {
       age: "thirty",
     };
 
-    // TODO: The error thrown must be of type SchemaError
     expect(() => parseSchema(schema, payload)).toThrow();
+    expect(() => parseSchema(schema, payload)).toThrow(SchemaError);
+    expect(() => parseSchema(schema, payload)).not.toThrow(ZodError);
   });
 });

--- a/packages/lib/src/schema/parse.ts
+++ b/packages/lib/src/schema/parse.ts
@@ -1,5 +1,8 @@
 import { SchemaType } from "./types";
 
-export function parseSchema<Schema = SchemaType>(schema: Schema) {
-  return schema.parse();
+export function parseSchema<Schema extends SchemaType>(
+  schema: Schema,
+  payload: unknown
+): Schema["_output"] {
+  return schema.parse(payload);
 }

--- a/packages/lib/src/schema/parse.ts
+++ b/packages/lib/src/schema/parse.ts
@@ -1,8 +1,20 @@
+import { ZodError } from "zod";
 import { SchemaType } from "./types";
+import { SchemaError } from "./SchemaError";
+
+export { SchemaError } from "./SchemaError";
 
 export function parseSchema<Schema extends SchemaType>(
   schema: Schema,
   payload: unknown
 ): Schema["_output"] {
-  return schema.parse(payload);
+  try {
+    const output = schema.parse(payload);
+    return output;
+  } catch (error) {
+    if(error instanceof ZodError) {
+      throw new SchemaError(error);
+    }
+    throw error;
+  }
 }

--- a/packages/lib/src/schema/parse.ts
+++ b/packages/lib/src/schema/parse.ts
@@ -1,0 +1,5 @@
+import { SchemaType } from "./types";
+
+export function parseSchema<Schema = SchemaType>(schema: Schema) {
+  return schema.parse();
+}

--- a/packages/lib/src/schema/types.ts
+++ b/packages/lib/src/schema/types.ts
@@ -1,0 +1,1 @@
+export type { ZodType as SchemaType } from "zod";

--- a/packages/lib/src/test.ts
+++ b/packages/lib/src/test.ts
@@ -1,1 +1,1 @@
-export * from "./test/generate";
+export * from "./test/index";

--- a/packages/lib/src/test/generate.ts
+++ b/packages/lib/src/test/generate.ts
@@ -1,3 +1,4 @@
+// TODO: Make this available on next release
 export function generate() {
   // This function is a placeholder for the actual implementation
   // that generates some output based on the schema.

--- a/packages/lib/src/test/generate.ts
+++ b/packages/lib/src/test/generate.ts
@@ -1,6 +1,1 @@
-// TODO: Make this available on next release
-export function generate() {
-  // This function is a placeholder for the actual implementation
-  // that generates some output based on the schema.
-  return "Generated output based on schema....";
-}
+export * from "./schemaGenerate";

--- a/packages/lib/src/test/index.ts
+++ b/packages/lib/src/test/index.ts
@@ -1,0 +1,1 @@
+export * from "./generate";

--- a/packages/lib/src/test/schemaGenerate/index.test.ts
+++ b/packages/lib/src/test/schemaGenerate/index.test.ts
@@ -11,7 +11,10 @@ describe("Schema Generation", () => {
       age: s.number(),
     })
 
-    const generatedSchema = schemaGenerate(schema);
+    const generatedSchema = schemaGenerate(schema, {
+      name: "john",
+    });
+
     expect(generatedSchema).to.have.keys([
       "name",
       "age",

--- a/packages/lib/src/test/schemaGenerate/index.test.ts
+++ b/packages/lib/src/test/schemaGenerate/index.test.ts
@@ -1,19 +1,34 @@
 import { describe, expect, it } from "vitest";
 import { schemaGenerate } from "./index";
 import { s } from "../../schema";
+import { bigDecimalSchema } from "../../big-decimal";
+import { BigDecimal } from "@omariosouto/common-core";
 
 describe("Schema Generation", () => {
   it("should generate a schema from a given object", () => {
     const schema = s.object({
       name: s.string(),
       age: s.number(),
+    })
+
+    const generatedSchema = schemaGenerate(schema);
+    expect(generatedSchema).to.have.keys([
+      "name",
+      "age",
+    ]);
+  });
+
+  it("should generate a schema from a given object with custom schemas", () => {
+    const schema = s.object({
+      price: bigDecimalSchema,
     });
 
     const generatedSchema = schemaGenerate(schema);
 
-    expect(Object.keys(generatedSchema)).to.have.keys([
-      "name",
-      "age",
+    expect(generatedSchema).to.have.keys([
+      "price",
     ]);
+
+    expect(generatedSchema.price).toBeInstanceOf(BigDecimal);
   });
 });

--- a/packages/lib/src/test/schemaGenerate/index.test.ts
+++ b/packages/lib/src/test/schemaGenerate/index.test.ts
@@ -5,7 +5,7 @@ import { bigDecimalSchema } from "../../big-decimal";
 import { BigDecimal } from "@omariosouto/common-core";
 
 describe("Schema Generation", () => {
-  it("should generate a schema from a given object", () => {
+  it.each([1, 2, 3, 4, 5])("should generate a schema from a given object", () => {
     const schema = s.object({
       name: s.string(),
       age: s.number(),
@@ -18,7 +18,7 @@ describe("Schema Generation", () => {
     ]);
   });
 
-  it("should generate a schema from a given object with custom schemas", () => {
+  it.each([1, 2, 3, 4, 5])("should generate a schema from a given object with custom schemas", () => {
     const schema = s.object({
       price: bigDecimalSchema,
     });

--- a/packages/lib/src/test/schemaGenerate/index.test.ts
+++ b/packages/lib/src/test/schemaGenerate/index.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { schemaGenerate } from "./index";
+import { s } from "../../schema";
+
+describe("Schema Generation", () => {
+  it("should generate a schema from a given object", () => {
+    const schema = s.object({
+      name: s.string(),
+      age: s.number(),
+    });
+
+    const generatedSchema = schemaGenerate(schema);
+
+    expect(Object.keys(generatedSchema)).to.have.keys([
+      "name",
+      "age",
+    ]);
+  });
+});

--- a/packages/lib/src/test/schemaGenerate/index.ts
+++ b/packages/lib/src/test/schemaGenerate/index.ts
@@ -9,7 +9,7 @@ interface SchemaGenerateOptions {
 }
 export function schemaGenerate<Schema extends SchemaType>(
   schema: Schema,
-  overrides: Partial<any> = {},
+  overrides?: Partial<s.infer<Schema>>,
   options: SchemaGenerateOptions = {},
 ): s.infer<Schema> {
   const fakeData = generateMock(schema as ZodTypeAny, {

--- a/packages/lib/src/test/schemaGenerate/index.ts
+++ b/packages/lib/src/test/schemaGenerate/index.ts
@@ -1,11 +1,17 @@
+
 import { generateMock } from '@anatine/zod-mock';
 import { merge } from "@omariosouto/common-core";
 import { ZodTypeAny } from "zod";
+import { s, SchemaType } from "../../schema";
 
 interface SchemaGenerateOptions {
   seed?: number;
 }
-export function schemaGenerate<Schema = any>(schema: Schema, overrides: Partial<any> = {}, options: SchemaGenerateOptions = {}) {
+export function schemaGenerate<Schema extends SchemaType>(
+  schema: Schema,
+  overrides: Partial<any> = {},
+  options: SchemaGenerateOptions = {},
+): s.infer<Schema> {
   const fakeData = generateMock(schema as ZodTypeAny, {
     seed: options.seed,
   });

--- a/packages/lib/src/test/schemaGenerate/index.ts
+++ b/packages/lib/src/test/schemaGenerate/index.ts
@@ -1,0 +1,13 @@
+import { generateMock } from '@anatine/zod-mock';
+import { merge } from "@omariosouto/common-core";
+import { ZodTypeAny } from "zod";
+
+interface SchemaGenerateOptions {
+  seed?: number;
+}
+export function schemaGenerate<Schema = any>(schema: Schema, overrides: Partial<any> = {}, options: SchemaGenerateOptions = {}) {
+  const fakeData = generateMock(schema as ZodTypeAny, {
+    seed: options.seed,
+  });
+  return merge(fakeData, overrides);
+}


### PR DESCRIPTION
## Lib Management

| Commands to manage version bumps |
| --- |
| bumper/release |
| bumper/beta    |
| bumper/skip    |

## Changelog

Adding support to:
- Throws `SchemaError`, always when using `parseSchema`
- When you are testing, you need to have fake data, for that use `generate` from the `/test` scope
